### PR TITLE
Support multiple target selectors for hiding elements and target verified badge

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,60 +1,66 @@
-function hideSpecifiedElement() {
-    const targetSelector = 'a[href="/i/twitter_blue_sign_up"][role="link"], a[href="/i/verified-orgs-signup"][role="link"]';
-    const twitterElements = document.querySelectorAll(targetSelector);
-    
-    for (const element of twitterElements) {
-        element.style.display = "none";
-    }
-}
+function hideSpecifiedElements(targetSelectors) {
+    for (const targetSelector of targetSelectors) {
+        const elements = document.querySelectorAll(targetSelector);
 
-function showSpecifiedElement() {
-    const targetSelector = 'a[href="/i/twitter_blue_sign_up"][role="link"], a[href="/i/verified-orgs-signup"][role="link"]';
-    const twitterElements = document.querySelectorAll(targetSelector);
-    
-    for (const element of twitterElements) {
-        element.style.display = "";
-    }
-}
-
-function applyToggleState(isEnabled) {
-    if (isEnabled) {
-        hideSpecifiedElement();
-    } else {
-        showSpecifiedElement();
-    }
-}
-
-function observeDOMChanges() {
-    const observer = new MutationObserver((mutationsList, observer) => {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList" && mutation.addedNodes.length > 0) {
-          chrome.storage.sync.get(["isEnabled"], (result) => {
-            if(result.isEnabled !== undefined){
-                applyToggleState(result.isEnabled);
-            }
-            else{
-                applyToggleState(true);
-            }
-          });
+        for (const element of elements) {
+            element.style.display = "none";
         }
-      }
+    }
+}
+
+function showSpecifiedElements(targetSelectors) {
+    for (const targetSelector of targetSelectors) {
+        const elements = document.querySelectorAll(targetSelector);
+
+        for (const element of elements) {
+            element.style.display = "";
+        }
+    }
+}
+
+function applyToggleState(isEnabled, targetSelectors) {
+    if (isEnabled) {
+        hideSpecifiedElements(targetSelectors);
+    } else {
+        showSpecifiedElements(targetSelectors);
+    }
+}
+
+function observeDOMChanges(targetSelectors) {
+    const observer = new MutationObserver((mutationsList, observer) => {
+        for (const mutation of mutationsList) {
+            if (mutation.type === "childList" && mutation.addedNodes.length > 0) {
+                chrome.storage.sync.get(["isEnabled"], (result) => {
+                    if (result.isEnabled !== undefined) {
+                        applyToggleState(result.isEnabled, targetSelectors);
+                    } else {
+                        applyToggleState(true, targetSelectors);
+                    }
+                });
+            }
+        }
     });
-  
-    // const observerTarget = document.querySelector('header[role="banner"].css-1dbjc4n.r-obd0qt.r-16y2uox.r-lrvibr.r-1g40b8q');
+
     observer.observe(document.body, { childList: true, subtree: true });
-  }
+}
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    applyToggleState(request.isEnabled);
+    applyToggleState(request.isEnabled, targetSelectors);
 });
 
-window.onload = observeDOMChanges;
+window.onload = () => observeDOMChanges(targetSelectors);
 
 chrome.storage.sync.get(["isEnabled"], (result) => {
-    if(result.isEnabled !== undefined){
-        applyToggleState(result.isEnabled);
-    }
-    else{
-        applyToggleState(true);
+    if (result.isEnabled !== undefined) {
+        applyToggleState(result.isEnabled, targetSelectors);
+    } else {
+        applyToggleState(true, targetSelectors);
     }
 });
+
+// Add target selectors to this array
+const targetSelectors = [
+    'a[href="/i/twitter_blue_sign_up"][role="link"]', // Twitter Blue signup
+    'a[href="/i/verified-orgs-signup"][role="link"]', // Verified Orgs signup
+    'svg[data-testid="icon-verified"]', // Verified badge
+];


### PR DESCRIPTION
### Description
This PR adds support for multiple target selectors to be hidden by the extension. This makes it more versatile and allows users to easily add or remove elements to be hidden on Twitter.com.

### Changes
1. Modified `hideSpecifiedElement` and `showSpecifiedElement` functions to accept an array of target selectors and iterate through them.
1. Updated the `applyToggleState` function to accept the array of target selectors.
1. Changed the `observeDOMChanges` function to work with multiple target selectors.
1. Added a new target selector for hiding the verified badge.
